### PR TITLE
Fixed license typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ base_model.label("./context_images", extension=".jpeg")
 
 ## License
 
-This model is licensed under an [Apache 2.0](LICENSE), [see original model implementation license](https://github.com/google-research/scenic/blob/main/LICENSE) (The license is for all scenic projects), and the corresponding [HuggingFace Transformers documentation](https://huggingface.co/docs/transformers/main/en/model_doc/owlv2).
+This model is licensed under an [Apache 2.0](LICENSE) ([see original model implementation license](https://github.com/google-research/scenic/blob/main/LICENSE) (The license is for all scenic projects), and the corresponding [HuggingFace Transformers documentation](https://huggingface.co/docs/transformers/main/en/model_doc/owlv2)).
 
 ## 🏆 Contributing
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ base_model.label("./context_images", extension=".jpeg")
 
 ## License
 
-This model is licensed under an [Apache 2.0](LICENSE) ([see original model implementation license](https://huggingface.co/docs/transformers/main/en/model_doc/owlv2), and the corresponding [HuggingFace Transformers documentation](https://huggingface.co/docs/transformers/main/en/model_doc/owlv2)).
+This model is licensed under an [Apache 2.0](LICENSE) ([see original model implementation license](https://github.com/google-research/scenic/blob/main/LICENSE) (The license is for all scenic projects), and the corresponding [HuggingFace Transformers documentation](https://huggingface.co/docs/transformers/main/en/model_doc/owlv2)).
 
 ## 🏆 Contributing
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ base_model.label("./context_images", extension=".jpeg")
 
 ## License
 
-This model is licensed under an [Apache 2.0](LICENSE) ([see original model implementation license](https://github.com/google-research/scenic/blob/main/LICENSE) (The license is for all scenic projects), and the corresponding [HuggingFace Transformers documentation](https://huggingface.co/docs/transformers/main/en/model_doc/owlv2)).
+This model is licensed under an [Apache 2.0](LICENSE), [see original model implementation license](https://github.com/google-research/scenic/blob/main/LICENSE) (The license is for all scenic projects), and the corresponding [HuggingFace Transformers documentation](https://huggingface.co/docs/transformers/main/en/model_doc/owlv2).
 
 ## 🏆 Contributing
 


### PR DESCRIPTION
## Issue
There was an error where the link for the original model license and the corresponding HF transformer documentation was the same. 

## Fix
The link was changed pointing to the LICENSE of scene projects that cover all google-research projects and is APACHE 2.0
